### PR TITLE
Fix buttons "disappear" issue on the Replacement Dialog

### DIFF
--- a/PluginCode/src/main/java/smr/cs/ualberta/libcomp/dialog/ReplacementDialog.java
+++ b/PluginCode/src/main/java/smr/cs/ualberta/libcomp/dialog/ReplacementDialog.java
@@ -478,7 +478,7 @@ public class ReplacementDialog extends JFrame {
         table.setSize(ColumnWidth, frameHeight);
         pane.setBorder(border);
         pane.setBounds(0, 0, ColumnWidth, frameHeight);
-        pane.setOpaque(true);
+        pane.setOpaque(false);
         getContentPane().add(pane);
         setSize(ColumnWidth, frameHeight + 50);
         //setSize(ColumnWidth, frameHeight + 10);


### PR DESCRIPTION
## Linked Issue https://github.com/ualberta-smr/LibCompPlugin/issues/43

## What is does
Fix buttons "disappear" issue on the Replacement Dialog. We had the problem of the buttons "disappear" once we start interacting with the dialog (e.g., clicking on the sort up/down buttons). After investigation, the button doesn't disappear, it still exist but becomes opaque. (We still can click the hidden "Cancel"  button to close the dialog).

## How to test it
- Checkout this branch `git checkout button-disappear-bug-fix`
- Compile and run as a plugin
- Open `Library Comparison` after right click red highlight
- [x] Click on chart/sort up/down buttons, you should still see the buttons exit. And then close the dialog
- Open `Library Comparison` dialog again
- [x] Click on desktop and go back to Library Comparison dialog, you should still see the buttons exit. And then close the dialog

